### PR TITLE
Add basic transaction db

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -51,6 +51,7 @@ from .interfaces import Comparator as IComparator
 from .interfaces import SliceTransform as ISliceTransform
 
 import traceback
+from .errors import Error
 from .errors import NotFound
 from .errors import Corruption
 from .errors import NotSupported

--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -29,6 +29,7 @@ from . cimport env
 from . cimport table_factory
 from . cimport memtablerep
 from . cimport universal_compaction
+from . cimport transaction_db
 
 # Enums are the only exception for direct imports
 # Their name als already unique enough
@@ -1791,6 +1792,90 @@ cdef class Options(ColumnFamilyOptions):
         def __set__(self, value):
             self.opts.best_efforts_recovery = value
 
+cdef class TransactionDBOptions(object):
+    cdef transaction_db.TransactionDBOptions* opts
+    cdef cpp_bool in_use
+
+    def __cinit__(self):
+        self.opts = new transaction_db.TransactionDBOptions()
+        self.in_use = False
+
+    def __dealloc__(self):
+        if not self.opts == NULL:
+            del self.opts
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    property max_num_locks:
+        def __get__(self):
+            return self.opts.max_num_locks
+        def __set__(self, value):
+            self.opts.max_num_locks = value
+
+    property max_num_deadlocks:
+        def __get__(self):
+            return self.opts.max_num_deadlocks
+        def __set__(self, value):
+            self.opts.max_num_deadlocks = value
+
+    property num_stripes:
+        def __get__(self):
+            return self.opts.num_stripes
+        def __set__(self, value):
+            self.opts.num_stripes = value
+
+    property transaction_lock_timeout:
+        def __get__(self):
+            return self.opts.transaction_lock_timeout
+        def __set__(self, value):
+            self.opts.transaction_lock_timeout = value
+
+    property default_lock_timeout:
+        def __get__(self):
+            return self.opts.default_lock_timeout
+        def __set__(self, value):
+            self.opts.default_lock_timeout = value
+
+    # TODO property custom_mutex_factory
+    property write_policy:
+        def __get__(self):
+            if self.opts.write_policy == transaction_db.WRITE_COMMITTED:
+                return 'write_committed'
+            if self.opts.write_policy == transaction_db.WRITE_PREPARED:
+                return 'write_prepared'
+            if self.opts.write_policy == transaction_db.WRITE_UNPREPARED:
+                return 'write_unprepared'
+            raise InvalidArgument("Unknown write policy")
+
+        def __set__(self, str value):
+            if value == 'write_committed':
+                self.opts.write_policy = transaction_db.WRITE_COMMITTED
+            elif value == 'write_prepared':
+                self.opts.write_policy = transaction_db.WRITE_PREPARED
+            elif value == 'write_unprepared':
+                self.opts.write_policy = transaction_db.WRITE_UNPREPARED
+            else:
+                raise InvalidArgument("Unknown write policy")
+
+    property rollback_merge_operands:
+        def __get__(self):
+            return self.opts.rollback_merge_operands
+        def __set__(self, value):
+            self.opts.rollback_merge_operands = value
+
+    property skip_concurrency_control:
+        def __get__(self):
+            return self.opts.skip_concurrency_control
+        def __set__(self, value):
+            self.opts.skip_concurrency_control = value
+
+    property default_write_batch_flush_threshold:
+        def __get__(self):
+            return self.opts.default_write_batch_flush_threshold
+        def __set__(self, value):
+            self.opts.default_write_batch_flush_threshold = value
 
 # Forward declaration
 cdef class Snapshot
@@ -1908,28 +1993,29 @@ cdef class WriteBatchIterator(object):
 @cython.no_gc_clear
 cdef class DB(object):
     cdef Options opts
-    cdef db.DB* db
+    cdef db.DB* wrapped_db
     cdef list cf_handles
     cdef list cf_options
+    cdef vector[db.ColumnFamilyDescriptor] column_family_descriptors
+    cdef vector[db.ColumnFamilyHandle*] column_family_handles
+    cdef string db_path
 
-    def __cinit__(self, db_name, Options opts, dict column_families=None, read_only=False):
+    def __cinit__(self, db_name, Options opts, dict column_families=None,
+                  read_only=False, *args, **kwargs):
         cdef Status st
-        cdef string db_path
-        cdef vector[db.ColumnFamilyDescriptor] column_family_descriptors
-        cdef vector[db.ColumnFamilyHandle*] column_family_handles
         cdef bytes default_cf_name = db.kDefaultColumnFamilyName
-        self.db = NULL
+        self.wrapped_db = NULL
         self.opts = None
         self.cf_handles = []
         self.cf_options = []
 
         if opts.in_use:
-            raise Exception("Options object is already used by another DB")
+            raise InvalidArgument(
+                "Options object is already used by another DB")
 
-        db_path = path_to_string(db_name)
         if not column_families or default_cf_name not in column_families:
             # Always add the default column family
-            column_family_descriptors.push_back(
+            self.column_family_descriptors.push_back(
                 db.ColumnFamilyDescriptor(
                     db.kDefaultColumnFamilyName,
                     options.ColumnFamilyOptions(deref(opts.opts))
@@ -1953,39 +2039,49 @@ cdef class DB(object):
                         "used by another Column Family"
                     )
                 (<ColumnFamilyOptions>cf_options).in_use = True
-                column_family_descriptors.push_back(
+                self.column_family_descriptors.push_back(
                     db.ColumnFamilyDescriptor(
                         cf_name,
                         deref((<ColumnFamilyOptions>cf_options).copts)
                     )
                 )
                 self.cf_options.append(cf_options)
+        if type(self) != DB:
+            return
+        db_path = path_to_string(db_name)
         if read_only:
             with nogil:
                 st = db.DB_OpenForReadOnly_ColumnFamilies(
                     deref(opts.opts),
                     db_path,
-                    column_family_descriptors,
-                    &column_family_handles,
-                    &self.db,
+                    self.column_family_descriptors,
+                    &self.column_family_handles,
+                    &self.wrapped_db,
                     False)
         else:
             with nogil:
                 st = db.DB_Open_ColumnFamilies(
                     deref(opts.opts),
                     db_path,
-                    column_family_descriptors,
-                    &column_family_handles,
-                    &self.db)
-        check_status(st)
+                    self.column_family_descriptors,
+                    &self.column_family_handles,
+                    &self.wrapped_db)
+        self.post_init_steps(st, opts)
 
-        for handle in column_family_handles:
+    cdef post_init_steps(self, Status st, Options opts):
+        check_status(st)
+        self.setup_handles()
+        self.inject_loggers(opts)
+
+    cdef setup_handles(self):
+        for handle in self.column_family_handles:
             wrapper = _ColumnFamilyHandle.from_handle_ptr(handle)
             self.cf_handles.append(wrapper)
 
+    cdef inject_loggers(self, Options opts):
         # Inject the loggers into the python callbacks
-        cdef shared_ptr[logger.Logger] info_log = self.db.GetOptions(
-            self.db.DefaultColumnFamily()).info_log
+        cdef shared_ptr[logger.Logger] info_log = self.wrapped_db.GetOptions(
+            self.wrapped_db.DefaultColumnFamily()).info_log
         if opts.py_comparator is not None:
             opts.py_comparator.set_info_log(info_log)
 
@@ -1994,13 +2090,13 @@ cdef class DB(object):
 
         if opts.prefix_extractor is not None:
             opts.py_prefix_extractor.set_info_log(info_log)
-
         cdef ColumnFamilyOptions copts
         for idx, copts in enumerate(self.cf_options):
             if not copts:
                 continue
 
-            info_log = self.db.GetOptions(column_family_handles[idx]).info_log
+            info_log = self.wrapped_db.GetOptions(
+                self.column_family_handles[idx]).info_log
 
             if copts.py_comparator is not None:
                 copts.py_comparator.set_info_log(info_log)
@@ -2018,10 +2114,10 @@ cdef class DB(object):
         cdef ColumnFamilyOptions copts
         cdef cpp_bool c_safe = safe
         cdef Status st
-        if self.db != NULL:
+        if self.wrapped_db != NULL:
             # We need stop backround compactions
             with nogil:
-                db.CancelAllBackgroundWork(self.db, c_safe)
+                db.CancelAllBackgroundWork(self.wrapped_db, c_safe)
             # We have to make sure we delete the handles so rocksdb doesn't
             # assert when we delete the db
             del self.cf_handles[:]
@@ -2030,8 +2126,8 @@ cdef class DB(object):
                     copts.in_use = False
             del self.cf_options[:]
             with nogil:
-                st = self.db.Close()
-                self.db = NULL
+                st = self.wrapped_db.Close()
+                self.wrapped_db = NULL
             if self.opts is not None:
                 self.opts.in_use = False
 
@@ -2063,12 +2159,12 @@ cdef class DB(object):
 
         cdef Slice c_key = bytes_to_slice(key)
         cdef Slice c_value = bytes_to_slice(value)
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
         with nogil:
-            st = self.db.Put(opts, cf_handle, c_key, c_value)
+            st = self.wrapped_db.Put(opts, cf_handle, c_key, c_value)
         check_status(st)
 
     def delete(self, key, sync=False, disable_wal=False, ignore_missing_column_families=False, no_slowdown=False, low_pri=False):
@@ -2086,12 +2182,12 @@ cdef class DB(object):
             column_family = None
 
         cdef Slice c_key = bytes_to_slice(key)
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
         with nogil:
-            st = self.db.Delete(opts, cf_handle, c_key)
+            st = self.wrapped_db.Delete(opts, cf_handle, c_key)
         check_status(st)
 
     def merge(self, key, value, sync=False, disable_wal=False, ignore_missing_column_families=False, no_slowdown=False, low_pri=False):
@@ -2110,12 +2206,12 @@ cdef class DB(object):
 
         cdef Slice c_key = bytes_to_slice(key)
         cdef Slice c_value = bytes_to_slice(value)
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
         with nogil:
-            st = self.db.Merge(opts, cf_handle, c_key, c_value)
+            st = self.wrapped_db.Merge(opts, cf_handle, c_key, c_value)
         check_status(st)
 
     def write(self, WriteBatch batch, sync=False, disable_wal=False, ignore_missing_column_families=False, no_slowdown=False, low_pri=False):
@@ -2128,7 +2224,7 @@ cdef class DB(object):
         opts.low_pri = low_pri
 
         with nogil:
-            st = self.db.Write(opts, batch.batch)
+            st = self.wrapped_db.Write(opts, batch.batch)
         check_status(st)
 
     def get(self, key, *args, **kwargs):
@@ -2144,12 +2240,12 @@ cdef class DB(object):
             column_family = None
 
         cdef Slice c_key = bytes_to_slice(key)
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
         with nogil:
-            st = self.db.Get(opts, cf_handle, c_key, cython.address(res))
+            st = self.wrapped_db.Get(opts, cf_handle, c_key, cython.address(res))
 
         if st.ok():
             return string_to_bytes(res)
@@ -2174,7 +2270,7 @@ cdef class DB(object):
                 py_handle, key = key
                 cf_handle = (<ColumnFamilyHandle?>py_handle).get_handle()
             else:
-                cf_handle = self.db.DefaultColumnFamily()
+                cf_handle = self.wrapped_db.DefaultColumnFamily()
             c_keys.push_back(bytes_to_slice(key))
             cf_handles.push_back(cf_handle)
 
@@ -2183,7 +2279,7 @@ cdef class DB(object):
 
         cdef vector[Status] res
         with nogil:
-            res = self.db.MultiGet(
+            res = self.wrapped_db.MultiGet(
                 opts,
                 cf_handles,
                 c_keys,
@@ -2218,7 +2314,7 @@ cdef class DB(object):
         cdef cpp_bool exists
         cdef options.ReadOptions opts
         cdef Slice c_key
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
 
         opts = self.build_read_opts(self.__parse_read_opts(*args, **kwargs))
         if isinstance(key, tuple):
@@ -2231,7 +2327,7 @@ cdef class DB(object):
         if fetch:
             value_found = False
             with nogil:
-                exists = self.db.KeyMayExist(
+                exists = self.wrapped_db.KeyMayExist(
                     opts,
                     cf_handle,
                     c_key,
@@ -2247,7 +2343,7 @@ cdef class DB(object):
                 return (False, None)
         else:
             with nogil:
-                exists = self.db.KeyMayExist(
+                exists = self.wrapped_db.KeyMayExist(
                     opts,
                     cf_handle,
                     c_key,
@@ -2258,7 +2354,7 @@ cdef class DB(object):
     def iterkeys(self, ColumnFamilyHandle column_family=None, *args, **kwargs):
         cdef options.ReadOptions opts
         cdef KeysIterator it
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = column_family.get_handle()
 
@@ -2266,13 +2362,13 @@ cdef class DB(object):
         it = KeysIterator(self, column_family)
 
         with nogil:
-            it.ptr = self.db.NewIterator(opts, cf_handle)
+            it.ptr = self.wrapped_db.NewIterator(opts, cf_handle)
         return it
 
     def itervalues(self, ColumnFamilyHandle column_family=None, *args, **kwargs):
         cdef options.ReadOptions opts
         cdef ValuesIterator it
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = column_family.get_handle()
 
@@ -2281,13 +2377,13 @@ cdef class DB(object):
         it = ValuesIterator(self)
 
         with nogil:
-            it.ptr = self.db.NewIterator(opts, cf_handle)
+            it.ptr = self.wrapped_db.NewIterator(opts, cf_handle)
         return it
 
     def iteritems(self, ColumnFamilyHandle column_family=None, *args, **kwargs):
         cdef options.ReadOptions opts
         cdef ItemsIterator it
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = column_family.get_handle()
         opts = self.build_read_opts(self.__parse_read_opts(*args, **kwargs))
@@ -2295,7 +2391,7 @@ cdef class DB(object):
         it = ItemsIterator(self, column_family)
 
         with nogil:
-            it.ptr = self.db.NewIterator(opts, cf_handle)
+            it.ptr = self.wrapped_db.NewIterator(opts, cf_handle)
         return it
 
     def iterskeys(self, column_families, *args, **kwargs):
@@ -2313,7 +2409,7 @@ cdef class DB(object):
 
         opts = self.build_read_opts(self.__parse_read_opts(*args, **kwargs))
         with nogil:
-            self.db.NewIterators(opts, cf_handles, &iters)
+            self.wrapped_db.NewIterators(opts, cf_handles, &iters)
 
         cf_iter = iter(column_families)
         cdef list ret = []
@@ -2338,7 +2434,7 @@ cdef class DB(object):
 
         opts = self.build_read_opts(self.__parse_read_opts(*args, **kwargs))
         with nogil:
-            self.db.NewIterators(opts, cf_handles, &iters)
+            self.wrapped_db.NewIterators(opts, cf_handles, &iters)
 
         cdef list ret = []
         for it_ptr in iters:
@@ -2362,7 +2458,7 @@ cdef class DB(object):
 
         opts = self.build_read_opts(self.__parse_read_opts(*args, **kwargs))
         with nogil:
-            self.db.NewIterators(opts, cf_handles, &iters)
+            self.wrapped_db.NewIterators(opts, cf_handles, &iters)
 
 
         cf_iter = iter(column_families)
@@ -2380,12 +2476,12 @@ cdef class DB(object):
         cdef string value
         cdef Slice c_prop = bytes_to_slice(prop)
         cdef cpp_bool ret = False
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = column_family.get_handle()
 
         with nogil:
-            ret = self.db.GetProperty(cf_handle, c_prop, cython.address(value))
+            ret = self.wrapped_db.GetProperty(cf_handle, c_prop, cython.address(value))
 
         if ret:
             return string_to_bytes(value)
@@ -2396,7 +2492,7 @@ cdef class DB(object):
         cdef vector[db.LiveFileMetaData] metadata
 
         with nogil:
-            self.db.GetLiveFilesMetaData(cython.address(metadata))
+            self.wrapped_db.GetLiveFilesMetaData(cython.address(metadata))
 
         ret = []
         for ob in metadata:
@@ -2416,12 +2512,12 @@ cdef class DB(object):
     def get_column_family_meta_data(self, ColumnFamilyHandle column_family=None):
         cdef db.ColumnFamilyMetaData metadata
 
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
         with nogil:
-            self.db.GetColumnFamilyMetaData(cf_handle, cython.address(metadata))
+            self.wrapped_db.GetColumnFamilyMetaData(cf_handle, cython.address(metadata))
 
         return {
             "size":metadata.size,
@@ -2462,11 +2558,11 @@ cdef class DB(object):
             end_val = bytes_to_slice(end)
             end_ptr = cython.address(end_val)
 
-        cdef db.ColumnFamilyHandle* cf_handle = self.db.DefaultColumnFamily()
+        cdef db.ColumnFamilyHandle* cf_handle = self.wrapped_db.DefaultColumnFamily()
         if column_family:
             cf_handle = (<ColumnFamilyHandle?>column_family).get_handle()
 
-        st = self.db.CompactRange(c_options, cf_handle, begin_ptr, end_ptr)
+        st = self.wrapped_db.CompactRange(c_options, cf_handle, begin_ptr, end_ptr)
         check_status(st)
 
     @staticmethod
@@ -2535,7 +2631,7 @@ cdef class DB(object):
 
         copts.in_use = True
         with nogil:
-            st = self.db.CreateColumnFamily(deref(copts.copts), c_name, &cf_handle)
+            st = self.wrapped_db.CreateColumnFamily(deref(copts.copts), c_name, &cf_handle)
         check_status(st)
 
         handle = _ColumnFamilyHandle.from_handle_ptr(cf_handle)
@@ -2552,7 +2648,7 @@ cdef class DB(object):
         cf_handle = weak_handle.get_handle()
 
         with nogil:
-            st = self.db.DropColumnFamily(cf_handle)
+            st = self.wrapped_db.DropColumnFamily(cf_handle)
         check_status(st)
 
         py_handle = weak_handle._ref()
@@ -2585,6 +2681,35 @@ def list_column_families(db_name, Options opts):
 
     return column_families
 
+@cython.no_gc_clear
+cdef class TransactionDB(DB):
+    cdef TransactionDBOptions tdb_opts
+
+    def __cinit__(self, db_name, Options opts,
+                  dict column_families=None,
+                  TransactionDBOptions tdb_opts=None,
+                  *args, **kwargs):
+        self.tdb_opts = None
+        db_path = path_to_string(db_name)
+        if tdb_opts.in_use:
+            raise InvalidArgument(
+                "Transaction Options object is already used by another DB")
+
+        with nogil:
+            st = transaction_db.TransactionDB_Open_ColumnFamilies(
+                deref(opts.opts),
+                deref(tdb_opts.opts),
+                db_path,
+                self.column_family_descriptors,
+                &self.column_family_handles,
+                <transaction_db.TransactionDB **>&self.wrapped_db)
+        self.post_init_steps(st, opts)
+        self.tdb_opts = tdb_opts
+        self.tdb_opts.in_use = True
+
+    property transaction_options:
+        def __get__(self):
+            return self.tdb_opts
 
 @cython.no_gc_clear
 @cython.internal
@@ -2595,13 +2720,12 @@ cdef class Snapshot(object):
     def __cinit__(self, DB db):
         self.db = db
         self.ptr = NULL
-        with nogil:
-            self.ptr = db.db.GetSnapshot()
+        with nogil: self.ptr = db.wrapped_db.GetSnapshot()
 
     def __dealloc__(self):
         if not self.ptr == NULL:
             with nogil:
-                self.db.db.ReleaseSnapshot(self.ptr)
+                self.db.wrapped_db.ReleaseSnapshot(self.ptr)
 
 
 @cython.internal
@@ -2763,7 +2887,7 @@ cdef class BackupEngine(object):
         c_flush_before_backup = flush_before_backup
 
         with nogil:
-            st = self.engine.CreateNewBackup(db.db, c_flush_before_backup)
+            st = self.engine.CreateNewBackup(db.wrapped_db, c_flush_before_backup)
         check_status(st)
 
     def restore_backup(self, backup_id, db_dir, wal_dir):

--- a/rocksdb/errors.py
+++ b/rocksdb/errors.py
@@ -1,20 +1,23 @@
-class NotFound(Exception):
+class Error(Exception):
     pass
 
-class Corruption(Exception):
+class NotFound(Error):
     pass
 
-class NotSupported(Exception):
+class Corruption(Error):
     pass
 
-class InvalidArgument(Exception):
+class NotSupported(Error):
     pass
 
-class RocksIOError(Exception):
+class InvalidArgument(Error):
     pass
 
-class MergeInProgress(Exception):
+class RocksIOError(Error):
     pass
 
-class Incomplete(Exception):
+class MergeInProgress(Error):
+    pass
+
+class Incomplete(Error):
     pass

--- a/rocksdb/slice_transform.pxd
+++ b/rocksdb/slice_transform.pxd
@@ -8,6 +8,12 @@ cdef extern from "rocksdb/slice_transform.h" namespace "rocksdb":
     cdef cppclass SliceTransform:
         pass
 
+    cdef const SliceTransform* ST_NewCappedPrefixTransform "rocksdb::NewCappedPrefixTransform"(
+        size_t) nogil except+
+
+    cdef const SliceTransform* ST_NewFixedPrefixTransform "rocksdb::NewFixedPrefixTransform"(
+        size_t) nogil except+
+
 ctypedef Slice (*transform_func)(
     void*,
     Logger*,

--- a/rocksdb/stackable_db.pxd
+++ b/rocksdb/stackable_db.pxd
@@ -1,0 +1,8 @@
+from libcpp.memory cimport shared_ptr
+from .db cimport DB
+
+cdef extern from "rocksdb/utilities/stackable_db.h" namespace "rocksdb":
+    cdef cppclass StackableDB(DB):
+        StackableDB(DB*) nogil except+
+        StackableDB(shared_ptr[DB] db) nogil except+
+        DB* GetBaseDB() nogil except+

--- a/rocksdb/tests/test_db.py
+++ b/rocksdb/tests/test_db.py
@@ -498,9 +498,9 @@ class TestFixedPrefixExtractor(TestHelper):
 
     def _fill_db(self):
         for x in range(3000):
-            keyx = hex(x)[2:].zfill(5).encode('utf8') + b'.x'
-            keyy = hex(x)[2:].zfill(5).encode('utf8') + b'.y'
-            keyz = hex(x)[2:].zfill(5).encode('utf8') + b'.z'
+            keyx = b'%05x.%b' % (x, b'x')
+            keyy = b'%05x.%b' % (x, b'y')
+            keyz = b'%05x.%b' % (x, b'z')
             self.db.put(keyx, b'x')
             self.db.put(keyy, b'y')
             self.db.put(keyz, b'z')

--- a/rocksdb/tests/test_db.py
+++ b/rocksdb/tests/test_db.py
@@ -19,7 +19,8 @@ class TestHelper(unittest.TestCase):
         self.addCleanup(self._close_db)
 
     def _close_db(self):
-        del self.db
+        if hasattr(self, 'db'):
+            del self.db
         gc.collect()
         if os.path.exists(self.db_loc):
             shutil.rmtree(self.db_loc)

--- a/rocksdb/tests/test_transaction_db.py
+++ b/rocksdb/tests/test_transaction_db.py
@@ -12,6 +12,8 @@ from rocksdb.merge_operators import UintAddOperator, StringAppendOperator
 from .test_db import TestHelper, TestDB
 
 class TestTransactionDB(TestDB):
+    """Re-run TestDB with the TransactionDB object"""
+
     def setUp(self):
         TestHelper.setUp(self)
         opts = rocksdb.Options(create_if_missing=True)
@@ -25,7 +27,9 @@ class TestTransactionDB(TestDB):
         expected = "Options object is already used by another DB"
         tdb_opts = rocksdb.TransactionDBOptions()
         with self.assertRaisesRegex(Exception, expected):
-            rocksdb.TransactionDB(os.path.join(self.db_loc, "test2"), self.db.options, tdb_opts=tdb_opts)
+            rocksdb.TransactionDB(os.path.join(self.db_loc, "test2"),
+                                  self.db.options,
+                                  tdb_opts=tdb_opts)
 
     def test_transaction_options_used_twice(self):
         expected = "Transaction Options object is already used by another DB"

--- a/rocksdb/tests/test_transaction_db.py
+++ b/rocksdb/tests/test_transaction_db.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import shutil
+import gc
+import unittest
+import rocksdb
+from itertools import takewhile
+import struct
+import tempfile
+from rocksdb.merge_operators import UintAddOperator, StringAppendOperator
+
+from .test_db import TestHelper, TestDB
+
+class TestTransactionDB(TestDB):
+    def setUp(self):
+        TestHelper.setUp(self)
+        opts = rocksdb.Options(create_if_missing=True)
+        tdb_opts = rocksdb.TransactionDBOptions()
+        self.db = rocksdb.TransactionDB(
+            os.path.join(self.db_loc, "test"),
+            opts,
+            tdb_opts=tdb_opts)
+
+    def test_options_used_twice(self):
+        expected = "Options object is already used by another DB"
+        tdb_opts = rocksdb.TransactionDBOptions()
+        with self.assertRaisesRegex(Exception, expected):
+            rocksdb.TransactionDB(os.path.join(self.db_loc, "test2"), self.db.options, tdb_opts=tdb_opts)
+
+    def test_transaction_options_used_twice(self):
+        expected = "Transaction Options object is already used by another DB"
+        opts = rocksdb.Options(create_if_missing=True)
+        with self.assertRaisesRegex(rocksdb.InvalidArgument, expected):
+            rocksdb.TransactionDB(os.path.join(self.db_loc, "test2"),
+                                  opts,
+                                  tdb_opts=self.db.transaction_options)

--- a/rocksdb/tests/test_transaction_db.py
+++ b/rocksdb/tests/test_transaction_db.py
@@ -26,7 +26,7 @@ class TestTransactionDB(TestDB):
     def test_options_used_twice(self):
         expected = "Options object is already used by another DB"
         tdb_opts = rocksdb.TransactionDBOptions()
-        with self.assertRaisesRegex(Exception, expected):
+        with self.assertRaisesRegex(rocksdb.InvalidArgument, expected):
             rocksdb.TransactionDB(os.path.join(self.db_loc, "test2"),
                                   self.db.options,
                                   tdb_opts=tdb_opts)

--- a/rocksdb/tests/test_transactiondb_options.py
+++ b/rocksdb/tests/test_transactiondb_options.py
@@ -1,0 +1,44 @@
+import unittest
+import sys
+import rocksdb
+
+class TestTransactionDBOptions(unittest.TestCase):
+    def test_default_getter_setter(self):
+        NOTNONE = object()
+        UNSETTABLE = object()
+        for option, def_value, new_value in (
+                ('max_num_locks', -1, 100),
+                ('max_num_deadlocks', 5, 10),
+                ('num_stripes', 16, 10),
+                ('transaction_lock_timeout', 1000, 100),
+                ('default_lock_timeout', 1000, 10000),
+                ('rollback_merge_operands', False, True),
+                ('skip_concurrency_control', False, True),
+                ('default_write_batch_flush_threshold', 0, 10)
+        ):
+            with self.subTest(option=option):
+                opts = rocksdb.TransactionDBOptions()
+                if def_value is NOTNONE:
+                    self.assertIsNotNone(getattr(opts, option))
+                else:
+                    self.assertEqual(def_value, getattr(opts, option))
+                if new_value is UNSETTABLE:
+                    self.assertRaises(
+                        Exception, setattr, opts, option, new_value)
+                else:
+                    setattr(opts, option, new_value)
+                    self.assertEqual(getattr(opts, option), new_value)
+
+    def test_write_policy(self):
+        opts = rocksdb.TransactionDBOptions()
+        self.assertEqual(opts.write_policy, 'write_committed')
+        accepted_values = ('write_committed',
+                           'write_prepared',
+                           'write_unprepared')
+        for value in accepted_values:
+            opts.write_policy = value
+            self.assertEqual(opts.write_policy, value)
+
+        error_value = 'write_dummy'
+        self.assertRaises(
+            rocksdb.InvalidArgument, setattr, opts, 'write_policy', error_value)

--- a/rocksdb/transaction_db.pxd
+++ b/rocksdb/transaction_db.pxd
@@ -1,0 +1,63 @@
+from . cimport options
+from libc.stdint cimport uint64_t, uint32_t, int64_t
+from .status cimport Status
+from libcpp cimport bool as cpp_bool
+from libcpp.string cimport string
+from libcpp.vector cimport vector
+from libcpp.memory cimport shared_ptr
+from .types cimport SequenceNumber
+from .db cimport DB, WriteBatch, ColumnFamilyDescriptor, ColumnFamilyHandle
+from .stackable_db cimport StackableDB
+
+cdef extern from "rocksdb/utilities/transaction_db.h" namespace "rocksdb":
+    cpdef enum TxnDBWritePolicy:
+        WRITE_COMMITTED
+        WRITE_PREPARED
+        WRITE_UNPREPARED
+
+    cdef cppclass TransactionDBOptions:
+        int64_t max_num_locks
+        uint32_t max_num_deadlocks
+        size_t num_stripes
+        int64_t transaction_lock_timeout
+        int64_t default_lock_timeout
+        # TODO shared_ptr[TransactionDBMutexFactory] custom_mutex_factory
+        TxnDBWritePolicy write_policy
+        cpp_bool rollback_merge_operands
+        cpp_bool skip_concurrency_control
+        int64_t default_write_batch_flush_threshold
+
+    cdef cppclass TransactionOptions:
+        cpp_bool set_snapshot
+        cpp_bool deadlock_detect
+        cpp_bool use_only_the_last_commit_time_batch_for_recovery
+        int64_t lock_timeout
+        int64_t expiration
+        int64_t deadlock_detect_depth
+        size_t max_write_batch_size
+        cpp_bool skip_concurrency_control
+        cpp_bool skip_prepare
+        int64_t write_batch_flush_threshold
+
+    cdef cppclass TransactionDBWriteOptimizations:
+        cpp_bool skip_concurrency_control
+        cpp_bool skip_duplicate_key_check
+
+    cdef cppclass TransactionDB(StackableDB):
+        Status Write(const options.WriteOptions&,
+                     const TransactionDBWriteOptimizations&,
+                     WriteBatch*) nogil except+
+
+    cdef Status TransactionDB_Open "rocksdb::TransactionDB::Open"(
+        const options.Options&,
+        const TransactionDBOptions&,
+        const string&,
+        TransactionDB**) nogil except+
+
+    cdef Status TransactionDB_Open_ColumnFamilies "rocksdb::TransactionDB::Open"(
+        const options.DBOptions&,
+        const TransactionDBOptions&,
+        const string&,
+        const vector[ColumnFamilyDescriptor]&,
+        vector[ColumnFamilyHandle*]*,
+        TransactionDB**) nogil except+


### PR DESCRIPTION
Adds the most basic TransactionDB class along with a simple unit test which is similar to the one in `test_db.py`. This is just to confirm that creating a TransactionDB is possible before going ahead with updating all the options classes and other helper PRs that are open.