### PR TITLE
Add workflow to also run tests on a Debian container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - 'main'
+      - 'force_ci/all/**'    # For development, forcing all workflows to run.
+      - 'force_ci/build/**'  # For debugging and/or only forcing this workflow.
 
 jobs:
   # Build the RocksDB C library and cache the result.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@
 name: 'Build'
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   # Build the RocksDB C library and cache the result.

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
   push:
     branches:
-      - main
-      - workflows/debian  # For debugging.
+      - 'main'
+      - 'force_ci/all/**'     # For development, forcing all workflows to run.
+      - 'force_ci/debian/**'  # For debugging and/or only forcing this workflow.
 
 jobs:
   debian-build:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,42 @@
+name: debian
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - workflows/debian  # For debugging.
+
+jobs:
+  debian-build:
+    name: ${{ matrix.dist }}
+    runs-on: ubuntu-latest
+    container: debian:${{ matrix.dist }}-slim
+    strategy:
+      fail-fast: false
+      matrix:
+        dist: [bullseye, bookworm]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install build-dependencies
+        # TODO(dato): find out why setup.py links to compression libraries
+        # by hand (and hence their development packages needed here).
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y \
+              build-essential librocksdb-dev cython3 \
+              python3-dev python3-pip python3-pytest \
+              libsnappy-dev libbz2-dev liblz4-dev libz-dev
+
+      - name: Symlink pytest
+        run: |
+          ln -s /usr/bin/pytest-3 /usr/local/bin/pytest
+
+      - name: Build pyrocksdb
+        run: |
+          python3 -m pip install '.[test]'
+
+      - name: Run tests
+        run: |
+          pytest --pyargs rocksdb


### PR DESCRIPTION
This runs tests against Debian stable (bullseye), and testing (bookworm).

-----
I'm having a weird segmentation fault problem on my machine, so I ended up wanting to make sure that things work in vanilla Debian (they seemingly do, so my error must be elsewhere).

I had said a few days ago that I wanted this check anyway, to ensure we can build/run against the pre-compiled librocksdb Debian packages.

N.B.: At the moment both bullseye and bookworm have 6.11, but 6.25 is in experimental, so it should make it to bookworm at some point..